### PR TITLE
Revert "Bump python from 3.10.7-slim-buster to 3.11.0rc2-slim-buster"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0rc2-slim-buster
+FROM python:3.10.7-slim-buster
 ARG BUILD_DATE
 ARG BUILD_URL
 ARG GIT_URL


### PR DESCRIPTION
Reverts evryfs/base-python#75